### PR TITLE
Use latest clorox

### DIFF
--- a/bench/package.json
+++ b/bench/package.json
@@ -5,6 +5,6 @@
     "ansi-colors": "^2.0.2",
     "benchmark": "^2.1.4",
     "chalk": "^2.4.0",
-    "clorox": "^2.0.0"
+    "clorox": "^2.2.0"
   }
 }


### PR DESCRIPTION
Hey @lukeed! This updates the bench/package.json to use the latest clorox. 👋 

---

I got the following results in Node v8.9.0 and v10.0.0 (MBP 2.4GHz Core i7 + 16 GB).

<img width="642" alt="screen shot 2018-07-13 at 19 08 18" src="https://user-images.githubusercontent.com/56996/42686521-3271aaec-86d1-11e8-8862-b84438d82439.png">


<img width="594" alt="screen shot 2018-07-13 at 19 10 52" src="https://user-images.githubusercontent.com/56996/42686522-32999480-86d1-11e8-83b2-49d94aec254a.png">
