### PR TITLE
Fix docs: use correct pkg name

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -123,7 +123,7 @@ const kleur = require('kleur');
 kleur.enabled = false;
 
 // or use a library to detect support
-kleur.enabled = require('color-support').stdout;
+kleur.enabled = require('supports-color').stdout;
 
 console.log(kleur.red('I will only be colored red if the terminal supports colors'));
 ```


### PR DESCRIPTION
You probably meant [**chalk/supports-color**](https://github.com/chalk/supports-color) and not [isaacs/color-support](https://github.com/isaacs/color-support), since the latter does not support `.stdout` as described in the docs.

👋  