### PR TITLE
Add badges for deps and install size

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -6,9 +6,6 @@
   <a href="https://npmjs.org/package/kleur">
     <img src="https://badgen.now.sh/npm/v/kleur" alt="version" />
   </a>
-  <a href="https://david-dm.org/lukeed/kleur">
-    <img src="https://badgen.now.sh/david/dep/lukeed/kleur" alt="dependencies" />
-  </a>
   <a href="https://travis-ci.org/lukeed/kleur">
     <img src="https://badgen.now.sh/travis/lukeed/kleur" alt="travis" />
   </a>

--- a/readme.md
+++ b/readme.md
@@ -4,16 +4,16 @@
 
 <div align="center">
   <a href="https://npmjs.org/package/kleur">
-    <img src="https://img.shields.io/npm/v/kleur.svg" alt="version" />
+    <img src="https://badgen.now.sh/npm/v/kleur" alt="version" />
   </a>
   <a href="https://david-dm.org/lukeed/kleur">
     <img src="https://badgen.now.sh/david/dep/lukeed/kleur" alt="dependencies" />
   </a>
   <a href="https://travis-ci.org/lukeed/kleur">
-    <img src="https://img.shields.io/travis/lukeed/kleur.svg" alt="travis" />
+    <img src="https://badgen.now.sh/travis/lukeed/kleur" alt="travis" />
   </a>
   <a href="https://npmjs.org/package/kleur">
-    <img src="https://img.shields.io/npm/dm/kleur.svg" alt="downloads" />
+    <img src="https://badgen.now.sh/npm/dm/kleur" alt="downloads" />
   </a>
   <a href="https://packagephobia.now.sh/result?p=kleur">
     <img src="https://packagephobia.now.sh/badge?p=kleur" alt="install size" />

--- a/readme.md
+++ b/readme.md
@@ -6,11 +6,17 @@
   <a href="https://npmjs.org/package/kleur">
     <img src="https://img.shields.io/npm/v/kleur.svg" alt="version" />
   </a>
+  <a href="https://david-dm.org/lukeed/kleur">
+    <img src="https://badgen.now.sh/david/dep/lukeed/kleur" alt="dependencies" />
+  </a>
   <a href="https://travis-ci.org/lukeed/kleur">
     <img src="https://img.shields.io/travis/lukeed/kleur.svg" alt="travis" />
   </a>
   <a href="https://npmjs.org/package/kleur">
     <img src="https://img.shields.io/npm/dm/kleur.svg" alt="downloads" />
+  </a>
+  <a href="https://packagephobia.now.sh/result?p=kleur">
+    <img src="https://packagephobia.now.sh/badge?p=kleur" alt="install size" />
   </a>
 </div>
 


### PR DESCRIPTION
These add a couple badges that prove there are 0 dependencies and that the npm install size is quite small 👍 

See [this tweet](https://twitter.com/amiocn/status/1019390390552522752) for more 😄 