### PR TITLE
Fix TypeScript declarations

### DIFF
--- a/kleur.d.ts
+++ b/kleur.d.ts
@@ -44,36 +44,8 @@ interface KleurInstance {
     strikethrough: KleurOrFunction;
 }
 
-/* Colors */
-export const black: KleurOrFunction;
-export const red: KleurOrFunction;
-export const green: KleurOrFunction;
-export const yellow: KleurOrFunction;
-export const blue: KleurOrFunction;
-export const magenta: KleurOrFunction;
-export const cyan: KleurOrFunction;
-export const white: KleurOrFunction;
-export const gray: KleurOrFunction;
-
-/* Background Colors */
-export const bgBlack: KleurOrFunction;
-export const bgRed: KleurOrFunction;
-export const bgGreen: KleurOrFunction;
-export const bgYellow: KleurOrFunction;
-export const bgBlue: KleurOrFunction;
-export const bgMagenta: KleurOrFunction;
-export const bgCyan: KleurOrFunction;
-export const bgWhite: KleurOrFunction;
-
-/* Modifiers */
-export const reset: KleurOrFunction;
-export const bold: KleurOrFunction;
-export const dim: KleurOrFunction;
-export const italic: KleurOrFunction;
-export const underline: KleurOrFunction;
-export const inverse: KleurOrFunction;
-export const hidden: KleurOrFunction;
-export const strikethrough: KleurOrFunction;
+declare let kleur: KleurInstance;
+export default kleur;
 
 /**
  * Enable ANSI Colors.


### PR DESCRIPTION
I think there's currently a mismatch between `index.js` and `index.d.ts`. The package itself has a `module.exports`, but the typings file has named exports. Currently, when I try to use kleur in a TypeScript project, I get red squigglies...

<img width="506" alt="screen shot 2018-08-28 at 5 49 56 pm" src="https://user-images.githubusercontent.com/1162160/44753030-d5c00300-aaea-11e8-8e92-abb03243a03c.png">

...and no auto-completion. If I change it to `import * as colors from 'kleur'` I get auto-completion and no red squigglies, but I get a build warning because 'bold is not exported by node_modules/kleur/index.js'.

This PR seems to fix it!