### PR TITLE
Make properties enumerable + fix TS typings

### DIFF
--- a/index.js
+++ b/index.js
@@ -100,6 +100,7 @@ function init(key) {
 for (let key in CODES) {
 	Object.defineProperty($, key, {
 		value: init(key),
+		enumerable: true,
 		writable: false
 	});
 }

--- a/kleur.d.ts
+++ b/kleur.d.ts
@@ -38,9 +38,7 @@ interface Kleur {
 	inverse: Color;
 	hidden: Color;
 	strikethrough: Color;
-
-	enabled: boolean;
 }
 
-declare let kleur: Kleur;
+declare let kleur: Kleur & { enabled: boolean };
 export = kleur;

--- a/kleur.d.ts
+++ b/kleur.d.ts
@@ -38,14 +38,9 @@ interface Kleur {
 	inverse: Color;
 	hidden: Color;
 	strikethrough: Color;
+
+	enabled: boolean;
 }
 
 declare let kleur: Kleur;
-export default kleur;
-
-/**
- * Note: ES6 imports are immutable
- * Therefore `kleur.enabled` can only be changed via
- *    import kleur = require('kleur');
- */
-export let enabled: boolean;
+export = kleur;


### PR DESCRIPTION
Thanks for making another awesome library! Have used it in a few personal projects so far and love it 👍 While working with it I'm wondering if you're open to these two suggestions:

**1) Make properties enumerable**

A simple `console.log(kleur)` would previously only show `enabled` property as available which might be confusing to newcomers. With this change it would list all available color properties.

**2) Fix TypeScript typings**

TS typings for `commonjs` modules are not as straightforward as for `es6` based libraries. If the libraries code is exported via `module.exports = myLib` one cannot declare it as `default` exports as this would create an ambiguity in regards to named exports.

This PR changes that to the [recommended way](https://www.typescriptlang.org/docs/handbook/modules.html#export--and-import--require) of changing the declaration to `export = myLib` (verified locally). 