### PR TITLE
add bright colors

### DIFF
--- a/index.js
+++ b/index.js
@@ -27,6 +27,16 @@ const $ = {
 	gray: init(90, 39),
 	grey: init(90, 39),
 
+	// bright colors
+	blackBright: init(90, 39),
+	redBright: init(91, 39),
+	greenBright: init(92, 39),
+	yellowBright: init(93, 39),
+	blueBright: init(94, 39),
+	magentaBright: init(95, 39),
+	cyanBright: init(96, 39),
+	whiteBright: init(97, 39),
+
 	// background colors
 	bgBlack: init(40, 49),
 	bgRed: init(41, 49),
@@ -35,7 +45,17 @@ const $ = {
 	bgBlue: init(44, 49),
 	bgMagenta: init(45, 49),
 	bgCyan: init(46, 49),
-	bgWhite: init(47, 49)
+	bgWhite: init(47, 49),
+
+	// bright background colors
+	bgBlackBright: init(100, 49),
+	bgRedBright: init(101, 49),
+	bgGreenBright: init(102, 49),
+	bgYellowBright: init(103, 49),
+	bgBlueBright: init(104, 49),
+	bgMagentaBright: init(105, 49),
+	bgCyanBright: init(106, 49),
+	bgWhiteBright: init(107, 49)
 };
 
 function run(arr, str) {
@@ -74,6 +94,15 @@ function chain(has, keys) {
 	ctx.gray = $.gray.bind(ctx);
 	ctx.grey = $.grey.bind(ctx);
 
+	ctx.blackBright = $.blackBright.bind(ctx);
+	ctx.redBright = $.redBright.bind(ctx);
+	ctx.greenBright = $.greenBright.bind(ctx);
+	ctx.yellowBright = $.yellowBright.bind(ctx);
+	ctx.blueBright = $.blueBright.bind(ctx);
+	ctx.magentaBright = $.magentaBright.bind(ctx);
+	ctx.cyanBright = $.cyanBright.bind(ctx);
+	ctx.whiteBright = $.whiteBright.bind(ctx);
+
 	ctx.bgBlack = $.bgBlack.bind(ctx);
 	ctx.bgRed = $.bgRed.bind(ctx);
 	ctx.bgGreen = $.bgGreen.bind(ctx);
@@ -82,6 +111,15 @@ function chain(has, keys) {
 	ctx.bgMagenta = $.bgMagenta.bind(ctx);
 	ctx.bgCyan = $.bgCyan.bind(ctx);
 	ctx.bgWhite = $.bgWhite.bind(ctx);
+
+	ctx.bgBlackBright = $.bgBlackBright.bind(ctx);
+	ctx.bgRedBright = $.bgRedBright.bind(ctx);
+	ctx.bgGreenBright = $.bgGreenBright.bind(ctx);
+	ctx.bgYellowBright = $.bgYellowBright.bind(ctx);
+	ctx.bgBlueBright = $.bgBlueBright.bind(ctx);
+	ctx.bgMagentaBright = $.bgMagentaBright.bind(ctx);
+	ctx.bgCyanBright = $.bgCyanBright.bind(ctx);
+	ctx.bgWhiteBright = $.bgWhiteBright.bind(ctx);
 
 	return ctx;
 }

--- a/kleur.d.ts
+++ b/kleur.d.ts
@@ -9,25 +9,41 @@ declare namespace kleur {
 	interface Kleur {
 		// Colors
 		black: Color;
+		blackBright: Color;
 		red: Color;
+		redBright: Color;
 		green: Color;
+		greenBright: Color;
 		yellow: Color;
+		yellowBright: Color;
 		blue: Color;
+		blueBright: Color;
 		magenta: Color;
+		magentaBright: Color;
 		cyan: Color;
+		cyanBright: Color;
 		white: Color;
+		whiteBright: Color;
 		gray: Color;
 		grey: Color;
 
 		// Backgrounds
 		bgBlack: Color;
+		bgBlackBright: Color;
 		bgRed: Color;
+		bgRedBright: Color;
 		bgGreen: Color;
+		bgGreenBright: Color;
 		bgYellow: Color;
+		bgYellowBright: Color;
 		bgBlue: Color;
+		bgBlueBright: Color;
 		bgMagenta: Color;
+		bgMagentaBright: Color;
 		bgCyan: Color;
+		bgCyanBright: Color;
 		bgWhite: Color;
+		bgWhiteBright: Color;
 
 		// Modifiers
 		reset: Color;

--- a/test/codes.js
+++ b/test/codes.js
@@ -21,6 +21,15 @@ module.exports = {
   gray: [90, 39],
   grey: [90, 39],
 
+  blackBright: [90, 39],
+  redBright: [91, 39],
+  greenBright: [92, 39],
+  yellowBright: [93, 39],
+  blueBright: [94, 39],
+  magentaBright: [95, 39],
+  cyanBright: [96, 39],
+  whiteBright: [97, 39],
+
   // background colors
   bgBlack: [40, 49],
   bgRed: [41, 49],
@@ -30,4 +39,13 @@ module.exports = {
   bgMagenta: [45, 49],
   bgCyan: [46, 49],
   bgWhite: [47, 49],
+
+  bgBlackBright: [100, 49],
+  bgRedBright: [101, 49],
+  bgGreenBright: [102, 49],
+  bgYellowBright: [103, 49],
+  bgBlueBright: [104, 49],
+  bgMagentaBright: [105, 49],
+  bgCyanBright: [106, 49],
+  bgWhiteBright: [107, 49]
 }


### PR DESCRIPTION
This PR adds foreground and background bright color variants.

ANSI codes copied from https://github.com/chalk/ansi-styles/blob/53ecb620fdfbc74a505799ab7bde875b6f4be472/index.js#L85-L112

Although I added the color codes to `test/codes.js` so they're picked up by the automatic tests, I didn't change anything in `test/index.js` to include the new bright colors.