### PR TITLE
fix: lazy `process` check

### DIFF
--- a/colors.mjs
+++ b/colors.mjs
@@ -1,4 +1,7 @@
-const { FORCE_COLOR, NODE_DISABLE_COLORS, TERM } = process.env;
+let FORCE_COLOR, NODE_DISABLE_COLORS, TERM;
+if (typeof process !== 'undefined') {
+	({ FORCE_COLOR, NODE_DISABLE_COLORS, TERM } = process.env);
+}
 
 export const $ = {
 	enabled: !NODE_DISABLE_COLORS && TERM !== 'dumb' && (

--- a/colors.mjs
+++ b/colors.mjs
@@ -1,11 +1,12 @@
-let FORCE_COLOR, NODE_DISABLE_COLORS, TERM;
+let FORCE_COLOR, NODE_DISABLE_COLORS, TERM, isTTY=true;
 if (typeof process !== 'undefined') {
 	({ FORCE_COLOR, NODE_DISABLE_COLORS, TERM } = process.env);
+	isTTY = process.stdout.isTTY;
 }
 
 export const $ = {
 	enabled: !NODE_DISABLE_COLORS && TERM !== 'dumb' && (
-		FORCE_COLOR != null && FORCE_COLOR !== '0' || process.stdout.isTTY
+		FORCE_COLOR != null && FORCE_COLOR !== '0' || isTTY
 	)
 }
 

--- a/index.mjs
+++ b/index.mjs
@@ -1,13 +1,14 @@
 'use strict';
 
-let FORCE_COLOR, NODE_DISABLE_COLORS, TERM;
+let FORCE_COLOR, NODE_DISABLE_COLORS, TERM, isTTY=true;
 if (typeof process !== 'undefined') {
 	({ FORCE_COLOR, NODE_DISABLE_COLORS, TERM } = process.env);
+	isTTY = process.stdout.isTTY;
 }
 
 const $ = {
 	enabled: !NODE_DISABLE_COLORS && TERM !== 'dumb' && (
-		FORCE_COLOR != null && FORCE_COLOR !== '0' || process.stdout.isTTY
+		FORCE_COLOR != null && FORCE_COLOR !== '0' || isTTY
 	),
 
 	// modifiers

--- a/index.mjs
+++ b/index.mjs
@@ -1,6 +1,9 @@
 'use strict';
 
-const { FORCE_COLOR, NODE_DISABLE_COLORS, TERM } = process.env;
+let FORCE_COLOR, NODE_DISABLE_COLORS, TERM;
+if (typeof process !== 'undefined') {
+	({ FORCE_COLOR, NODE_DISABLE_COLORS, TERM } = process.env);
+}
 
 const $ = {
 	enabled: !NODE_DISABLE_COLORS && TERM !== 'dumb' && (


### PR DESCRIPTION
Allows browser-based imports to bypass the need to shim `process.env` and `process.stdout`.

> **Note:** Only basic ANSI color codes (red, blue, bgYellow, etc -- ***no modifiers***) work in the browser.

---

Related: https://github.com/lukeed/uvu/issues/37