### PR TITLE
Fix `NO_COLOR` support

### DIFF
--- a/colors.mjs
+++ b/colors.mjs
@@ -5,7 +5,7 @@ if (typeof process !== 'undefined') {
 }
 
 export const $ = {
-	enabled: !NODE_DISABLE_COLORS && NO_COLOR === undefined && TERM !== 'dumb' && (
+	enabled: !NODE_DISABLE_COLORS && NO_COLOR == null && TERM !== 'dumb' && (
 		FORCE_COLOR != null && FORCE_COLOR !== '0' || isTTY
 	)
 }

--- a/colors.mjs
+++ b/colors.mjs
@@ -5,7 +5,7 @@ if (typeof process !== 'undefined') {
 }
 
 export const $ = {
-	enabled: !NODE_DISABLE_COLORS && !NO_COLOR && TERM !== 'dumb' && (
+	enabled: !NODE_DISABLE_COLORS && NO_COLOR === undefined && TERM !== 'dumb' && (
 		FORCE_COLOR != null && FORCE_COLOR !== '0' || isTTY
 	)
 }

--- a/index.mjs
+++ b/index.mjs
@@ -7,7 +7,7 @@ if (typeof process !== 'undefined') {
 }
 
 const $ = {
-	enabled: !NODE_DISABLE_COLORS && !NO_COLOR && TERM !== 'dumb' && (
+	enabled: !NODE_DISABLE_COLORS && NO_COLOR === undefined && TERM !== 'dumb' && (
 		FORCE_COLOR != null && FORCE_COLOR !== '0' || isTTY
 	),
 

--- a/index.mjs
+++ b/index.mjs
@@ -7,7 +7,7 @@ if (typeof process !== 'undefined') {
 }
 
 const $ = {
-	enabled: !NODE_DISABLE_COLORS && NO_COLOR === undefined && TERM !== 'dumb' && (
+	enabled: !NODE_DISABLE_COLORS && NO_COLOR == null && TERM !== 'dumb' && (
 		FORCE_COLOR != null && FORCE_COLOR !== '0' || isTTY
 	),
 


### PR DESCRIPTION
Fixes #38 

Checks that `NO_COLOR` is present to disable the colors. Sorry for missing this in the spec the first time around.

@lukeed It might be nice to share this enabled logic between the 2 implementations. I'm unsure how that would affect the bench for kleur. 

Also, I noticed that `env.sh` isn't running for tests. I had troubles with getting it to fail with the old logic or the new logic. I instead ran `NO_COLOR= yarn test` to see if it was disabling the colors and it appeared to work.