### PR TITLE
Fix NO_COLOR handling to comply with the spec

### DIFF
--- a/colors.mjs
+++ b/colors.mjs
@@ -1,12 +1,14 @@
 let FORCE_COLOR, NODE_DISABLE_COLORS, NO_COLOR, TERM, isTTY=true;
 if (typeof process !== 'undefined') {
-	({ FORCE_COLOR, NODE_DISABLE_COLORS, NO_COLOR, TERM } = process.env);
+	({ FORCE_COLOR, NODE_DISABLE_COLORS, TERM } = process.env);
+	FORCE_COLOR = FORCE_COLOR || '0';
+	NO_COLOR = 'NO_COLOR' in process.env;
 	isTTY = process.stdout.isTTY;
 }
 
 export const $ = {
 	enabled: !NODE_DISABLE_COLORS && !NO_COLOR && TERM !== 'dumb' && (
-		FORCE_COLOR != null && FORCE_COLOR !== '0' || isTTY
+		FORCE_COLOR !== '0' || isTTY
 	)
 }
 

--- a/index.mjs
+++ b/index.mjs
@@ -2,13 +2,15 @@
 
 let FORCE_COLOR, NODE_DISABLE_COLORS, NO_COLOR, TERM, isTTY=true;
 if (typeof process !== 'undefined') {
-	({ FORCE_COLOR, NODE_DISABLE_COLORS, NO_COLOR, TERM } = process.env);
+	({ FORCE_COLOR, NODE_DISABLE_COLORS, TERM } = process.env);
+	FORCE_COLOR = FORCE_COLOR || '0';
+	NO_COLOR = 'NO_COLOR' in process.env;
 	isTTY = process.stdout.isTTY;
 }
 
 const $ = {
 	enabled: !NODE_DISABLE_COLORS && !NO_COLOR && TERM !== 'dumb' && (
-		FORCE_COLOR != null && FORCE_COLOR !== '0' || isTTY
+		FORCE_COLOR !== '0' || isTTY
 	),
 
 	// modifiers

--- a/package.json
+++ b/package.json
@@ -29,7 +29,8 @@
   },
   "scripts": {
     "build": "node build",
-    "test": "uvu -r esm -i utils -i xyz"
+    "test": "uvu -r esm -i utils -i xyz",
+    "test:env": "bats ./test/env.bats"
   },
   "engines": {
     "node": ">=6"
@@ -43,6 +44,7 @@
     "terminal"
   ],
   "devDependencies": {
+    "bats": "^1.2.1",
     "esm": "3.2.25",
     "uvu": "0.0.16"
   }

--- a/test/env.bats
+++ b/test/env.bats
@@ -1,0 +1,190 @@
+#!/usr/bin/env bats
+
+# vim:ft=bash:
+
+# CMD='node -r esm ./test/xyz.js'
+CMD='node --trace-warnings -r esm ./test/xyz.js'
+COLOR=$'\E[31mfoo\E[39m'
+NO_COLOR='foo'
+
+faketty() {
+	script -qfc "$(printf "%q " "$@")" /dev/null | tr -d '\r'
+}
+
+# process.stdout.isTTY = undefined;
+
+@test "[tty=false] FORCE_COLOR=?" {
+	result=$($CMD)
+	[ "$result" = "$NO_COLOR" ]
+}
+
+@test "[tty=false] FORCE_COLOR=" {
+	result=$(FORCE_COLOR= $CMD)
+	[ "$result" = "$NO_COLOR" ]
+}
+
+@test "[tty=false] FORCE_COLOR=''" {
+	result=$(FORCE_COLOR='' $CMD)
+	[ "$result" = "$NO_COLOR" ]
+}
+
+@test "[tty=false] FORCE_COLOR=0" {
+	result=$(FORCE_COLOR=0 $CMD)
+	[ "$result" = "$NO_COLOR" ]
+}
+
+@test "[tty=false] NODE_DISABLE_COLORS=1" {
+	result=$(NODE_DISABLE_COLORS=1 $CMD)
+	[ "$result" = "$NO_COLOR" ]
+}
+
+@test "[tty=false] NODE_DISABLE_COLORS=1; FORCE_COLOR=1" {
+	result=$(NODE_DISABLE_COLORS=1 FORCE_COLOR=1 $CMD)
+	[ "$result" = "$NO_COLOR" ]
+}
+
+@test "[tty=false] NO_COLOR=" {
+	result=$(NO_COLOR= $CMD)
+	[ "$result" = "$NO_COLOR" ]
+}
+
+@test "[tty=false] NO_COLOR=''" {
+	result=$(NO_COLOR='' $CMD)
+	[ "$result" = "$NO_COLOR" ]
+}
+
+@test "[tty=false] NO_COLOR=0" {
+	result=$(NO_COLOR=0 $CMD)
+	[ "$result" = "$NO_COLOR" ]
+}
+
+@test "[tty=false] NO_COLOR=1" {
+	result=$(NO_COLOR=1 $CMD)
+	[ "$result" = "$NO_COLOR" ]
+}
+
+@test "[tty=false] NO_COLOR=yes" {
+	result=$(NO_COLOR=yes $CMD)
+	[ "$result" = "$NO_COLOR" ]
+}
+
+@test "[tty=false] NO_COLOR=; FORCE_COLOR=1" {
+	result=$(NO_COLOR= FORCE_COLOR=1 $CMD)
+	[ "$result" = "$NO_COLOR" ]
+}
+
+@test "[tty=false] NO_COLOR=0; FORCE_COLOR=1" {
+	result=$(NO_COLOR=0 FORCE_COLOR=1 $CMD)
+	[ "$result" = "$NO_COLOR" ]
+}
+
+@test "[tty=false] NO_COLOR=1; FORCE_COLOR=1" {
+	result=$(NO_COLOR=1 FORCE_COLOR=1 $CMD)
+	[ "$result" = "$NO_COLOR" ]
+}
+
+@test "[tty=false] FORCE_COLOR=1" {
+	result=$(FORCE_COLOR=1 $CMD)
+	[ "$result" = "$COLOR" ]
+}
+
+@test "[tty=false] FORCE_COLOR=2" {
+	result=$(FORCE_COLOR=2 $CMD)
+	[ "$result" = "$COLOR" ]
+}
+
+@test "[tty=false] TERM=dumb; FORCE_COLOR=1" {
+	result=$(TERM=dumb FORCE_COLOR=1 $CMD)
+	[ "$result" = "$NO_COLOR" ]
+}
+
+@test "[tty=false] TERM=dumb" {
+	result=$(TERM=dumb $CMD)
+	[ "$result" = "$NO_COLOR" ]
+}
+
+# process.stdout.isTTY = true;
+
+@test "[tty=true] FORCE_COLOR=?" {
+	result=$(faketty $CMD)
+	[ "$result" = "$COLOR" ]
+}
+
+@test "[tty=true] FORCE_COLOR=" {
+	result=$(FORCE_COLOR= faketty $CMD)
+	[ "$result" = "$COLOR" ]
+}
+
+@test "[tty=true] FORCE_COLOR=''" {
+	result=$(FORCE_COLOR='' faketty $CMD)
+	[ "$result" = "$COLOR" ]
+}
+
+@test "[tty=true] FORCE_COLOR=0" {
+	result=$(FORCE_COLOR=0 faketty $CMD)
+	[ "$result" = "$COLOR" ]
+}
+
+@test "[tty=true] NODE_DISABLE_COLORS=1" {
+	result=$(NODE_DISABLE_COLORS=1 faketty $CMD)
+	[ "$result" = "$NO_COLOR" ]
+}
+
+@test "[tty=true] NODE_DISABLE_COLORS=1; FORCE_COLOR=1" {
+	result=$(NODE_DISABLE_COLORS=1 FORCE_COLOR=1 faketty $CMD)
+	printf "XXX result: [%q]" "$result"
+	[ "$result" = "$NO_COLOR" ]
+}
+
+@test "[tty=true] NO_COLOR=" {
+	result=$(NO_COLOR= faketty $CMD)
+	[ "$result" = "$NO_COLOR" ]
+}
+
+@test "[tty=true] NO_COLOR=''" {
+	result=$(NO_COLOR='' faketty $CMD)
+	[ "$result" = "$NO_COLOR" ]
+}
+
+@test "[tty=true] NO_COLOR=0" {
+	result=$(NO_COLOR=0 faketty $CMD)
+	[ "$result" = "$NO_COLOR" ]
+}
+
+@test "[tty=true] NO_COLOR=1" {
+	result=$(NO_COLOR=1 faketty $CMD)
+	[ "$result" = "$NO_COLOR" ]
+}
+
+@test "[tty=true] NO_COLOR=; FORCE_COLOR=1" {
+	result=$(NO_COLOR= FORCE_COLOR=1 faketty $CMD)
+	printf "XXX result: [%q]" "$result"
+	[ "$result" = "$NO_COLOR" ]
+}
+
+@test "[tty=true] NO_COLOR=0; FORCE_COLOR=1" {
+	result=$(NO_COLOR=0 FORCE_COLOR=1 faketty $CMD)
+	printf "XXX result: [%q]" "$result"
+	[ "$result" = "$NO_COLOR" ]
+}
+
+@test "[tty=true] NO_COLOR=1; FORCE_COLOR=1" {
+	result=$(NO_COLOR=1 FORCE_COLOR=1 faketty $CMD)
+	printf "XXX result: [%q]" "$result"
+	[ "$result" = "$NO_COLOR" ]
+}
+
+@test "[tty=true] TERM=dumb; FORCE_COLOR=1" {
+	result=$(TERM=dumb FORCE_COLOR=1 faketty $CMD)
+	[ "$result" = "$NO_COLOR" ]
+}
+
+@test "[tty=true] FORCE_COLOR=1" {
+	result=$(FORCE_COLOR=1 faketty $CMD)
+	[ "$result" = "$COLOR" ]
+}
+
+@test "[tty=true] FORCE_COLOR=2" {
+	result=$(FORCE_COLOR=2 faketty $CMD)
+	[ "$result" = "$COLOR" ]
+}


### PR DESCRIPTION
Closes #38

disable color with NO_COLOR:

before:

    $ NO_COLOR=1 command  # ✔
    $ NO_COLOR=0 command  # ✔
    $ NO_COLOR= command   # x
    $ NO_COLOR="" command # x

after:

    $ NO_COLOR=1 command  # ✔
    $ NO_COLOR=0 command  # ✔
    $ NO_COLOR= command   # ✔
    $ NO_COLOR="" command # ✔

also:

- don't equate `FORCE_COLOR=""` with `FORCE_COLOR=1`
- add environment-variable tests (based on [`test/env.sh`](https://github.com/lukeed/kleur/blob/v4.1.1/test/env.sh))

Note that the 4 tests which combine `NO_COLOR` and `FORCE_COLOR` fail on Node.js >= v12 because it has elected to [issue a warning](https://github.com/nodejs/node/pull/26485) if both are defined.