### PR TITLE
Fixed browser support

### DIFF
--- a/colors.mjs
+++ b/colors.mjs
@@ -1,7 +1,7 @@
 let FORCE_COLOR, NODE_DISABLE_COLORS, NO_COLOR, TERM, isTTY=true;
-if (typeof process !== 'undefined' && process.stdout) {
+if (typeof process !== 'undefined') {
 	({ FORCE_COLOR, NODE_DISABLE_COLORS, NO_COLOR, TERM } = process.env);
-	isTTY = process.stdout.isTTY;
+	isTTY = process.stdout && process.stdout.isTTY;
 }
 
 export const $ = {

--- a/colors.mjs
+++ b/colors.mjs
@@ -1,5 +1,5 @@
 let FORCE_COLOR, NODE_DISABLE_COLORS, NO_COLOR, TERM, isTTY=true;
-if (typeof process !== 'undefined') {
+if (typeof process !== 'undefined' && process.stdout) {
 	({ FORCE_COLOR, NODE_DISABLE_COLORS, NO_COLOR, TERM } = process.env);
 	isTTY = process.stdout.isTTY;
 }

--- a/index.mjs
+++ b/index.mjs
@@ -1,9 +1,9 @@
 'use strict';
 
 let FORCE_COLOR, NODE_DISABLE_COLORS, NO_COLOR, TERM, isTTY=true;
-if (typeof process !== 'undefined' && process.stdout) {
+if (typeof process !== 'undefined') {
 	({ FORCE_COLOR, NODE_DISABLE_COLORS, NO_COLOR, TERM } = process.env);
-	isTTY = process.stdout.isTTY;
+	isTTY = process.stdout && process.stdout.isTTY;
 }
 
 const $ = {

--- a/index.mjs
+++ b/index.mjs
@@ -1,7 +1,7 @@
 'use strict';
 
 let FORCE_COLOR, NODE_DISABLE_COLORS, NO_COLOR, TERM, isTTY=true;
-if (typeof process !== 'undefined') {
+if (typeof process !== 'undefined' && process.stdout) {
 	({ FORCE_COLOR, NODE_DISABLE_COLORS, NO_COLOR, TERM } = process.env);
 	isTTY = process.stdout.isTTY;
 }


### PR DESCRIPTION
Hey @lukeed how are you?

Every bundler like browserify, parcel and webpack is using a shim of `process` that doesn't have `stdout` implemented.

So when I try to use kleur in the browser it throws an error that process.stdout is undefined.

With this minor change we can have support for the browser too.