### PR TITLE
Add colorette to the benchmarks

### DIFF
--- a/bench/colors.js
+++ b/bench/colors.js
@@ -1,5 +1,6 @@
 const chalk = require('chalk');
 const ansi = require('ansi-colors');
+const colorette = require('colorette');
 const { Suite } = require('benchmark');
 const colors = require('../colors');
 const kleur = require('../index');
@@ -24,6 +25,9 @@ bench('All Colors')
 	.add('chalk', () => {
 		names.forEach(name => chalk[name]('foo'));
 	})
+	.add('colorette', () => {
+		names.forEach(name => colorette[name]('foo'));
+	})
 	.add('kleur', () => {
 		names.forEach(name => kleur[name]('foo'));
 	})
@@ -40,6 +44,9 @@ bench('Stacked colors')
 	.add('chalk', () => {
 		names.forEach(name => chalk[name].bold.underline.italic('foo'));
 	})
+	.add('colorette', () => {
+		names.forEach(name => colorette[name](colorette.bold(colorette.underline(colorette.italic('foo')))));
+	})
 	.add('kleur', () => {
 		names.forEach(name => kleur[name]().bold().underline().italic('foo'));
 	})
@@ -52,6 +59,7 @@ bench('Stacked colors')
 bench('Nested colors')
 	.add('ansi-colors', () => fixture(ansi))
 	.add('chalk', () => fixture(chalk))
+	.add('colorette', () => fixture(colorette))
 	.add('kleur', () => fixture(kleur))
 	.add('kleur/colors', () => fixture(colors))
 	.run();

--- a/bench/load.js
+++ b/bench/load.js
@@ -13,3 +13,7 @@ console.timeEnd('kleur/colors');
 console.time('ansi-colors');
 const color = require('ansi-colors');
 console.timeEnd('ansi-colors');
+
+console.time('colorette');
+const colorette = require('colorette');
+console.timeEnd('colorette');

--- a/bench/package.json
+++ b/bench/package.json
@@ -3,6 +3,7 @@
   "devDependencies": {
     "ansi-colors": "4.1.1",
     "benchmark": "2.1.4",
-    "chalk": "4.0.0"
+    "chalk": "4.1.0",
+    "colorette": "1.2.1"
   }
 }


### PR DESCRIPTION
Attempts to fix #35. I upgraded chalk to the latest (minor) version too.

Both `kleur` and `colorette` are the fastest with `colorette` having the upper hand. It appears that `kleur` trades run-time for loading-time performance :-)

The numbers:

    $ node load

    chalk: 11.326ms
    kleur: 0.662ms
    kleur/colors: 0.438ms
    ansi-colors: 1.961ms
    colorette: 2.13ms

    $ node colors

    # All Colors
      ansi-colors      x 218,607 ops/sec ±0.35% (91 runs sampled)
      chalk            x 918,282 ops/sec ±0.26% (96 runs sampled)
      colorette        x 1,529,758 ops/sec ±0.87% (96 runs sampled)
      kleur            x 1,166,639 ops/sec ±0.64% (92 runs sampled)
      kleur/colors     x 1,426,030 ops/sec ±0.23% (93 runs sampled)

    # Stacked colors
      ansi-colors      x 26,428 ops/sec ±0.95% (94 runs sampled)
      chalk            x 589,847 ops/sec ±0.15% (94 runs sampled)
      colorette        x 115,505 ops/sec ±0.81% (93 runs sampled)
      kleur            x 89,383 ops/sec ±1.10% (93 runs sampled)
      kleur/colors     x 111,107 ops/sec ±0.10% (97 runs sampled)

    # Nested colors
      ansi-colors      x 78,378 ops/sec ±0.08% (93 runs sampled)
      chalk            x 127,300 ops/sec ±0.21% (97 runs sampled)
      colorette        x 160,043 ops/sec ±0.22% (98 runs sampled)
      kleur            x 135,730 ops/sec ±1.11% (94 runs sampled)
      kleur/colors     x 144,491 ops/sec ±0.40% (97 runs sampled)
