### PR TITLE
fix: use `indexOf` instead of `includes` to support ES5 browsers

### DIFF
--- a/colors.mjs
+++ b/colors.mjs
@@ -16,7 +16,7 @@ function init(x, y) {
 
 	return function (txt) {
 		if (!$.enabled || txt == null) return txt;
-		return open + ((''+txt).includes(close) ? txt.replace(rgx, close + open) : txt) + close;
+		return open + (!!~(''+txt).indexOf(close) ? txt.replace(rgx, close + open) : txt) + close;
 	};
 }
 

--- a/index.mjs
+++ b/index.mjs
@@ -50,7 +50,7 @@ function run(arr, str) {
 		tmp = arr[i];
 		beg += tmp.open;
 		end += tmp.close;
-		if (str.includes(tmp.close)) {
+		if (!!~str.indexOf(tmp.close)) {
 			str = str.replace(tmp.rgx, tmp.close + tmp.open);
 		}
 	}
@@ -100,7 +100,7 @@ function init(open, close) {
 	};
 	return function (txt) {
 		if (this !== void 0 && this.has !== void 0) {
-			this.has.includes(open) || (this.has.push(open),this.keys.push(blk));
+			!!~this.has.indexOf(open) || (this.has.push(open),this.keys.push(blk));
 			return txt === void 0 ? this : $.enabled ? run(this.keys, txt+'') : txt+'';
 		}
 		return txt === void 0 ? chain([open], [blk]) : $.enabled ? run([blk], txt+'') : txt+'';


### PR DESCRIPTION
I'd like to use `kleur` inside the isomorphic `js-reporters` library, as used inside the QUnit application. We still support a number of plain ES5 browsers, such as IE11, and this one function call inside kleur is currently requiring a polyfill to ship with our standard distribution.

The code is very unlikely to be needed inside a browser, but I'm not sure how else to avoid it, also since the colors are enabled by default when Node/`process` is undefined. This is fine for us, but it'd help us a lot to avoid these two function calls for now.