### PR TITLE
fix: handle undefined `process.env`

### DIFF
--- a/colors.mjs
+++ b/colors.mjs
@@ -1,6 +1,6 @@
 let FORCE_COLOR, NODE_DISABLE_COLORS, NO_COLOR, TERM, isTTY=true;
 if (typeof process !== 'undefined') {
-	({ FORCE_COLOR, NODE_DISABLE_COLORS, NO_COLOR, TERM } = process.env);
+	({ FORCE_COLOR, NODE_DISABLE_COLORS, NO_COLOR, TERM } = process.env || {});
 	isTTY = process.stdout && process.stdout.isTTY;
 }
 

--- a/index.mjs
+++ b/index.mjs
@@ -2,7 +2,7 @@
 
 let FORCE_COLOR, NODE_DISABLE_COLORS, NO_COLOR, TERM, isTTY=true;
 if (typeof process !== 'undefined') {
-	({ FORCE_COLOR, NODE_DISABLE_COLORS, NO_COLOR, TERM } = process.env);
+	({ FORCE_COLOR, NODE_DISABLE_COLORS, NO_COLOR, TERM } = process.env || {});
 	isTTY = process.stdout && process.stdout.isTTY;
 }
 


### PR DESCRIPTION
Kleur highly uses in multiple packages like `micromark` and it may include in client bundle, therefore there are some cases that `process.env` could be undefined.

This change ensure that missing `process.env` does not lead to runtime exception