### PR TITLE
Add types to export map

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,21 +4,21 @@
   "repository": "lukeed/kleur",
   "description": "The fastest Node.js library for formatting terminal text with ANSI colors~!",
   "module": "index.mjs",
-  "types": "index.d.ts",
   "main": "index.js",
   "license": "MIT",
   "exports": {
     ".": {
+      "types": "./index.d.ts",
       "import": "./index.mjs",
-      "require": "./index.js",
-      "types": "./index.d.ts"
+      "require": "./index.js"
     },
     "./colors": {
+      "types": "./colors.d.ts",
       "import": "./colors.mjs",
       "require": "./colors.js",
-      "types": "./colors.d.ts"
     }
   },
+  "types": "index.d.ts",
   "files": [
     "*.d.ts",
     "colors.*",

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "repository": "lukeed/kleur",
   "description": "The fastest Node.js library for formatting terminal text with ANSI colors~!",
   "module": "index.mjs",
+  "types": "index.d.ts",
   "main": "index.js",
   "license": "MIT",
   "exports": {
@@ -18,7 +19,6 @@
       "require": "./colors.js"
     }
   },
-  "types": "index.d.ts",
   "files": [
     "*.d.ts",
     "colors.*",

--- a/package.json
+++ b/package.json
@@ -10,11 +10,13 @@
   "exports": {
     ".": {
       "import": "./index.mjs",
-      "require": "./index.js"
+      "require": "./index.js",
+      "types": "./index.d.ts"
     },
     "./colors": {
       "import": "./colors.mjs",
-      "require": "./colors.js"
+      "require": "./colors.js",
+      "types": "./colors.d.ts"
     }
   },
   "files": [

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "./colors": {
       "types": "./colors.d.ts",
       "import": "./colors.mjs",
-      "require": "./colors.js",
+      "require": "./colors.js"
     }
   },
   "types": "index.d.ts",


### PR DESCRIPTION
https://devblogs.microsoft.com/typescript/announcing-typescript-4-7/#package-json-exports-imports-and-self-referencing

TS 4.7 adds a new resolution mode which matches node's built in ESM resolution. TS adds a `types` export condition which allows it to resolve types for, e.g. `kleur/colors`.

The existing `types` field outside of `exports` is left as a fallback for older TS versions or for people not using the new resolution mode.